### PR TITLE
[#15] Fix of overlapping command line options

### DIFF
--- a/CLI/Options.cs
+++ b/CLI/Options.cs
@@ -11,7 +11,7 @@ namespace Emul8.CLI
 {
 	internal class Options
 	{
-        [Name('c', "console"), DefaultValue(false), Description("Set the output for console window instead of many terminals.")]
+        [Name("console"), DefaultValue(false), Description("Set the output for console window instead of many terminals.")]
         public bool ConsoleMode { get; set; }
 
         [Name('s', "stdinout"), DefaultValue(false), Description("Read input from standard input and write to standard output - for use in pipes (this option is exclusive with -e and startup script passed as an argument).")]

--- a/CLI/Options.cs
+++ b/CLI/Options.cs
@@ -7,7 +7,7 @@
 //
 using Antmicro.OptionsParser;
 
-namespace Emul8.CLI 
+namespace Emul8.CLI
 {
 	internal class Options
 	{

--- a/Tools/Emul8-Launcher/Emul8-Launcher/Options.cs
+++ b/Tools/Emul8-Launcher/Emul8-Launcher/Options.cs
@@ -23,7 +23,7 @@ namespace Emul8.Launcher
         [Description("Do not output errors on console.")]
         public bool Quiet { get; set; }
         
-        [Name('p', "port"), Description("Listen for external debugger."), DefaultValue(-1)]
+        [Name("external-debugger-port"), Description("Listen for external debugger."), DefaultValue(-1)]
         public int DebuggerSocketPort { get; set; }
 
         public bool Validate(out string error)

--- a/Tools/Emul8-Launcher/Emul8-Launcher/Options.cs
+++ b/Tools/Emul8-Launcher/Emul8-Launcher/Options.cs
@@ -5,7 +5,7 @@
 // This file is part of the Emul8 project.
 // Full license details are defined in the 'LICENSE' file.
 //
-﻿using Antmicro.OptionsParser;
+using Antmicro.OptionsParser;
 
 namespace Emul8.Launcher
 {
@@ -19,10 +19,10 @@ namespace Emul8.Launcher
     {
         [Name('d', "debug"), Description("Use non-optimized, debugabble version.")]
         public bool Debug { get; set; }
-        
+
         [Description("Do not output errors on console.")]
         public bool Quiet { get; set; }
-        
+
         [Name("external-debugger-port"), Description("Listen for external debugger."), DefaultValue(-1)]
         public int DebuggerSocketPort { get; set; }
 
@@ -33,7 +33,7 @@ namespace Emul8.Launcher
                 error = "Debugger is not available in 'Release' mode";
                 return false;
             }
-            
+
             error = null;
             return true;
         }

--- a/doc/source/running.rst
+++ b/doc/source/running.rst
@@ -21,7 +21,7 @@ To run Emul8, use the :program:`run.sh` script, with the optional ``file`` param
 
 .. program:: run.sh
 
-.. option:: -c
+.. option:: --console
 
    Do not open a separate terminal for the CLI but use the one from which it is run.
 


### PR DESCRIPTION
This pull request contains set of commits fixing problem with overlapping command line options as well as bumping `options-parser` library to the newest version.