### PR TITLE
[FIX] Fix testing script's internal paths.

### DIFF
--- a/Emulator/run_tests.py
+++ b/Emulator/run_tests.py
@@ -7,7 +7,7 @@ import argparse
 import subprocess
 import signal
 
-nunit_path = os.path.join(os.path.dirname(__file__), os.path.abspath('./../External/Tools/nunit-console.exe'))
+nunit_path = os.path.abspath(os.path.join(os.path.dirname(__file__), './../External/Tools/nunit-console.exe'))
 bin_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), 'tests'))
 
 test_projects = map(os.path.abspath, [


### PR DESCRIPTION
Commit 1b57d4587c6aa01078aa33907848200cf5b54c19 introduced
a wrong way of calculating absolute path to `nunit` binary.
This commit fixes it.