### PR TITLE
Move script for running tests to `Tools/scripts` directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ Emulator/Main/AssemblyVersionInfo.cs
 packages
 
 #tests
-Emulator/tests
+Tools/scripts/tests

--- a/Tools/scripts/run_tests.py
+++ b/Tools/scripts/run_tests.py
@@ -7,13 +7,13 @@ import argparse
 import subprocess
 import signal
 
-nunit_path = os.path.abspath(os.path.join(os.path.dirname(__file__), './../External/Tools/nunit-console.exe'))
+nunit_path = os.path.abspath(os.path.join(os.path.dirname(__file__), './../../External/Tools/nunit-console.exe'))
 bin_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), 'tests'))
 
 test_projects = map(os.path.abspath, [
-        "Main/Tests/UnitTests/UnitTests.csproj",
-        "Peripherals/Test/PeripheralsTests/PeripheralsTests.csproj",
-        "Extensions/MonitorTests/MonitorTests.csproj",
+        "./../../Main/Tests/UnitTests/UnitTests.csproj",
+        "./../../Peripherals/Test/PeripheralsTests/PeripheralsTests.csproj",
+        "./../../Extensions/MonitorTests/MonitorTests.csproj",
 ])
 
 def get_project(project_id):


### PR DESCRIPTION
This pull request provides solution for issue #26.