### PR TITLE
Build 32-bit version of SPARC CPU.

### DIFF
--- a/Emulator/Cores/cores-sparc.csproj
+++ b/Emulator/Cores/cores-sparc.csproj
@@ -24,7 +24,6 @@
     <PropertyGroup>
       <Architecture>sparc</Architecture>
       <EmulatedTarget>sparc</EmulatedTarget>
-      <TargetWordSize>64</TargetWordSize>
     </PropertyGroup>
     <ItemGroup>
       <Endianess Include="le" />


### PR DESCRIPTION
64-bit version was not tested properly and
it's implementation was removed.