### PR TITLE
[FIX] Eliminate race condition from `FileBackend`.

### DIFF
--- a/Emulator/Main/Logging/Backends/FileBackend.cs
+++ b/Emulator/Main/Logging/Backends/FileBackend.cs
@@ -18,12 +18,8 @@ namespace Emul8.Logging
         {
             var stream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
             output = new StreamWriter(stream);
-            timer = new Timer(delegate
-            {
-                Flush();
-            }, null, 0, 5000);
             sync = new object();
-
+            timer = new Timer(x => Flush(), null, 0, 5000);
         }
 
         public override void Log(LogEntry entry)


### PR DESCRIPTION
It was possible to execute `Flush` method before creating
`sync` object, which could lead to NullReferenceException.