### PR TITLE
[FIX] Workaround for a bug in mono.

### DIFF
--- a/Emulator/Peripherals/Peripherals/Timers/SunxiHighSpeedTimer.cs
+++ b/Emulator/Peripherals/Peripherals/Timers/SunxiHighSpeedTimer.cs
@@ -261,6 +261,13 @@ namespace Emul8.Peripherals.Timers
                 }
             }
 
+            // THIS IS A WORKAROUND FOR A BUG IN MONO
+            // https://bugzilla.xamarin.com/show_bug.cgi?id=39444
+            protected override void OnLimitReached()
+            {
+                base.OnLimitReached();
+            }
+
             private void OnModeChange(bool oldValue, bool newValue)
             {
                 Mode = newValue ? WorkMode.OneShot : WorkMode.Periodic;

--- a/Emulator/Peripherals/Peripherals/Timers/SunxiTimer.cs
+++ b/Emulator/Peripherals/Peripherals/Timers/SunxiTimer.cs
@@ -235,6 +235,13 @@ namespace Emul8.Peripherals.Timers
                 }
             }
 
+            // THIS IS A WORKAROUND FOR A BUG IN MONO
+            // https://bugzilla.xamarin.com/show_bug.cgi?id=39444
+            protected override void OnLimitReached()
+            {
+                base.OnLimitReached();
+            }
+
             private void OnClockSourceChange(ClockSource oldValue, ClockSource newValue)
             {
                 switch(newValue)

--- a/Emulator/Peripherals/Peripherals/Timers/TegraUsecTimer.cs
+++ b/Emulator/Peripherals/Peripherals/Timers/TegraUsecTimer.cs
@@ -20,10 +20,15 @@ namespace Emul8.Peripherals.Timers
             Reset ();
         }
 
+        // THIS IS A WORKAROUND FOR A BUG IN MONO
+        // https://bugzilla.xamarin.com/show_bug.cgi?id=39444
+        protected override void OnLimitReached()
+        {
+            base.OnLimitReached();
+        }
+
         public uint ReadDoubleWord (long offset)
         {
-
-
             switch ((Registers)offset) 
             {
             case Registers.Value:


### PR DESCRIPTION
This commit adds default override for
timer's virtual `OnLimitReached` method
in order to make delegates to it comparable.
This is a known issue in mono, reported here:
https://bugzilla.xamarin.com/show_bug.cgi?id=39444.