### PR TITLE
[#6083] Remove properties.csproj file from target before bootstrapping.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -96,6 +96,7 @@ xbuild $CCTASK_DIR/CCTask.sln /p:Configuration=Release /nologo /verbosity:quiet 
 
 OS_NAME=`uname`
 
+rm -f $OUTPUT_DIRECTORY/properties.csproj
 if [ "$OS_NAME" == "Darwin" ]
 then
   mkdir -p $OUTPUT_DIRECTORY


### PR DESCRIPTION
This is needed when the whole Emul8's directory is copied from
OSX to Linux operating system in order to generate valid build setup.