### PR TITLE
[#6121] Fix detecting if analyzer is hidden.

### DIFF
--- a/Emulator/Main/Peripherals/BackendManager.cs
+++ b/Emulator/Main/Peripherals/BackendManager.cs
@@ -183,7 +183,7 @@ namespace Emul8.Peripherals
                 }
 
                 var hidden = arg.GetCustomAttributes(typeof(HideInMonitorAttribute), true).Any();
-                analyzers[arg].Add(Tuple.Create(t, hidden));
+                analyzers[arg].Add(Tuple.Create(t, !hidden));
             }
 
             var backendTypes = interestingInterfaces.Where(i => i.GetGenericTypeDefinition() == typeof(IAnalyzableBackend<>)).SelectMany(i => i.GetGenericArguments()).ToArray();


### PR DESCRIPTION
There was an error in code which reverted the logic making
hidden analyzers visible and vice versa.